### PR TITLE
BUGFIX: PlaywrightConnector uses magic $request

### DIFF
--- a/Tests/Behavior/Bootstrap/PlaywrightConnector.php
+++ b/Tests/Behavior/Bootstrap/PlaywrightConnector.php
@@ -165,7 +165,7 @@ class PlaywrightConnector
 
         $curlResult = curl_exec($curlHandle);
         if ($curlResult === false) {
-            throw new \RuntimeException(sprintf('cURL reported error code %s with message "%s". Last requested URL was "%s" (%s).', curl_errno($curlHandle), curl_error($curlHandle), curl_getinfo($curlHandle, CURLINFO_EFFECTIVE_URL), $request->getMethod()), 1338906040);
+            throw new \RuntimeException(sprintf('cURL reported error code %s with message "%s". Last requested URL was "%s" (%s).', curl_errno($curlHandle), curl_error($curlHandle), curl_getinfo($curlHandle, CURLINFO_EFFECTIVE_URL), $method), 1338906040);
         }
 
         curl_close($curlHandle);


### PR DESCRIPTION
Fix a bug for Symfony support where the PlaywrightConnector uses the magic `$request` variable of Flow to get the method name of the request that was send when the curl command fails.

Fix: Use available `$method` variable of the local scope.