### PR TITLE
BUGFIX: iClickTheDocumentTreeEntry for Neos 8.3

### DIFF
--- a/Tests/Behavior/Bootstrap/NeosBackendControlTrait.php
+++ b/Tests/Behavior/Bootstrap/NeosBackendControlTrait.php
@@ -76,7 +76,7 @@ trait NeosBackendControlTrait
         $this->playwrightConnector->execute($this->playwrightContext, sprintf(
         // language=JavaScript
             '
-            await vars.page.click(`body div[class^=style__leftSideBar__top___] div[role=button]:has(span:has-text("%s"))`);
+            await vars.page.locator("body div[class*=leftSideBar__top]").getByRole("button", {name: "%s"}).click();
             await vars.page.waitForSelector(`div#neos-Inspector`);
             vars.neosContentFrame = await vars.page.frame(`neos-content-main`);
         '// language=PHP


### PR DESCRIPTION
will fix #24 

With Neos 8.3 the bundling of the UI has changed a lot. For this reason the class names are now very different.

Sample:

Neos 8.1: `style__leftSideBar__top___3hY-V`
Neos 8.3: `Ls2IoG_leftSideBar__top`